### PR TITLE
StorageProof type and changes to Toml export

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ mod utils;
 mod election;
 mod serialisation;
 
+// Useful constants for storage proofs
+pub(crate) const MAX_NODE_LEN: usize = 532; // The maximum byte length of a node
+pub(crate) const MAX_DEPTH: usize = 8; // For technical reasons, we need a fixed maximum trie proof size.
 
 /// Define the reexported types from the arkworks libraries to be used in this crate
 pub(crate) use ark_bn254::{G1Projective as BN254_G1, Fr as BN254_Fr};
@@ -38,8 +41,14 @@ pub fn run() -> Result<(), String> {
     let toml_private_string = toml::to_string_pretty(&vote_package.private_input.toml()).map_err(|e| format!("Failed to generate toml for private_input: {}", e.to_string()))?;
     let toml_public_string = toml::to_string_pretty(&vote_package.public_input.toml()).map_err(|e| format!("Failed to generate toml for public_input: {}", e.to_string()))?;
 
+    // Move to circuit directory
+    std::env::set_current_dir("circuit").map_err(|e| e.to_string())?;
+
+    // Write Toml files
     fs::write("Prover.toml", toml_private_string.add(&*toml_public_string.clone())).map_err(|e| e.to_string())?;
     fs::write("Verifier.toml", toml_public_string).map_err(|e| e.to_string())?;
+
+    // Generate proof
 
     Ok(())
 }

--- a/src/preprover.rs
+++ b/src/preprover.rs
@@ -13,16 +13,26 @@ use poseidon_ark::Poseidon;
 use toml::{Table, Value};
 use crate::{concat_vec, BN254_G1, Voter, BN254_Fr, BBJJ_Fr, BBJJ_G1};
 use crate::election::{ElectionIdentifier, VoteChoice};
-
+use crate::MAX_NODE_LEN;
+use crate::MAX_DEPTH;
 
 #[derive(Debug)]
-pub struct StorageProofPLACEHOLDER {
-    // TODO - parametrise this with Ahmad's work
+pub struct StorageProof {
+    pub(crate) path: Vec<Vec<u8>>,
+    pub(crate) depth: usize
 }
 
-
-
-
+impl StorageProof {
+    pub fn new(path: Vec<Vec<u8>>) -> Self
+    {
+        let depth = path.len();
+        // More checks necessary in reality, but these will catch obviously invalid proofs.
+        assert!(depth <= MAX_DEPTH, "The maximum possible proof depth ({}) has been exceeded!", MAX_DEPTH);
+        path.iter().for_each(|node| {assert!(node.len() <= MAX_NODE_LEN, "Invalid node!");});
+        
+        StorageProof {path, depth}
+    }
+}
 
 #[derive(Debug)]
 pub struct PublicInput {
@@ -39,9 +49,9 @@ pub struct PrivateInput {
     pub(crate) TAU_i: Signature,
     pub(crate) id: ElectionIdentifier,
     pub(crate) RCK_i: BBJJ_G1,
-    pub(crate) p_1: StorageProofPLACEHOLDER,
-    pub(crate) p_2: StorageProofPLACEHOLDER,
-    pub(crate) p_3: StorageProofPLACEHOLDER,
+    pub(crate) p_1: StorageProof,
+    pub(crate) p_2: StorageProof,
+    pub(crate) p_3: StorageProof,
 }
 
 #[derive(Debug)]

--- a/src/serialisation/bn254_fr.rs
+++ b/src/serialisation/bn254_fr.rs
@@ -3,10 +3,10 @@ use babyjubjub_ark::Signature;
 use crate::election::{ElectionIdentifier, VoteChoice};
 use crate::{BN254_Fr, BBJJ_Fr, BN254_G1, BBJJ_G1, concat_vec};
 
-use crate::preprover::StorageProofPLACEHOLDER;
+use crate::preprover::StorageProof;
 use crate::serialisation::Wrapper;
 
-impl Into<Vec<BN254_Fr>> for StorageProofPLACEHOLDER {
+impl Into<Vec<BN254_Fr>> for StorageProof {
     fn into(self) -> Vec<BN254_Fr> {
         vec![]
     }

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -2,12 +2,12 @@ use ark_ec::Group;
 use ark_std::rand::Rng;
 use ark_std::UniformRand;
 use poseidon_ark::Poseidon;
-use babyjubjub_ark::PrivateKey as PrivateBBJJKey;
+use babyjubjub_ark::{PrivateKey as PrivateBBJJKey};
 
 use crate::{BN254_Fr, BN254_G1, concat_vec};
 use crate::election::{ElectionParams, VoteChoice};
 use crate::utils::Mock;
-use crate::preprover::{PrivateInput, PublicInput, StorageProofPLACEHOLDER, VoteProverPackage};
+use crate::preprover::{PrivateInput, PublicInput, StorageProof, VoteProverPackage};
 use crate::serialisation::Wrapper;
 
 
@@ -53,9 +53,9 @@ impl Voter {
 
         let B_i = poseidon.hash(concat_vec![<Wrapper<BN254_G1> as Into<Vec<BN254_Fr>>>::into(Wrapper(K_i)), vec![v_i.clone().into(), election_params.identifier.chain_id, election_params.identifier.process_id, election_params.identifier.contract_addr]])?; // Poseidon(K_i, vote_choice, election_params.identifier);
 
-        let p_1 = StorageProofPLACEHOLDER {}; // TODO // Storage Prove of NFT ownership by voter address
-        let p_2 = StorageProofPLACEHOLDER {}; // TODO // Storage Prove that NFT has not been delegated
-        let p_3 = StorageProofPLACEHOLDER {}; // TODO // Storage Prove that g^RK_i is in the registry under the voter's address
+        let p_1 = StorageProof::new(vec![]); // TODO // Storage Prove of NFT ownership by voter address
+        let p_2 = StorageProof::new(vec![]); // TODO // Storage Prove that NFT has not been delegated
+        let p_3 = StorageProof::new(vec![]); // TODO // Storage Prove that g^RK_i is in the registry under the voter's address
 
         let proverPackage = VoteProverPackage {
             public_input: PublicInput {


### PR DESCRIPTION
Summary of this PR's changes:
- Introduction of a `StorageProof` type together with an appropriate Toml serialisation. Note that we require some hardcoded constants to limit the maximum depth and node sizes, which mirrors the Noir implementation.
- The `Prover.toml` and `Verifier.toml` are placed in the `circuit` directory rather than the project root.
- Variable names in the Toml output have been changed to match the Noir code (to be incorporated in a separate PR).